### PR TITLE
в режиме fastCGI и xcf4 нужно явно устанавливать encoding в ответе

### DIFF
--- a/src/ASPNETHandler/ASPNETHandler.cs
+++ b/src/ASPNETHandler/ASPNETHandler.cs
@@ -138,6 +138,8 @@ namespace OneScript.ASPNETHandler
                     response.BodyStream.CopyTo(context.Response.OutputStream);
                 }
 
+                context.Response.Charset = response.ContentCharset;
+
             }
             catch (ScriptInterruptionException e)
             {

--- a/src/ASPNETHandler/HTTPServiceResponse.cs
+++ b/src/ASPNETHandler/HTTPServiceResponse.cs
@@ -58,6 +58,7 @@ namespace ScriptEngine.HostedScript.Library.HTTPService
         ScriptEngine.HostedScript.Library.MapImpl _headers = new HostedScript.Library.MapImpl();
         string _reason = "";
         int _statusCode = 200;
+        string _contentCharset = Encoding.UTF8.WebName;
 
         System.IO.Stream _bodyStream = new System.IO.MemoryStream();
 
@@ -66,6 +67,14 @@ namespace ScriptEngine.HostedScript.Library.HTTPService
             get
             {
                 return _bodyStream;
+            }
+        }
+
+        public string ContentCharset
+        {
+            get
+            {
+                return _contentCharset;
             }
         }
 
@@ -179,6 +188,8 @@ namespace ScriptEngine.HostedScript.Library.HTTPService
             System.Text.Encoding enc = System.Text.Encoding.UTF8;
             if (encoding != null)
                 enc = TextEncodingEnum.GetEncoding(encoding);
+
+            _contentCharset = enc.WebName;
 
             _bodyStream = new System.IO.MemoryStream();
             byte[] buffer = enc.GetBytes(str);


### PR DESCRIPTION
сервера под Linux автоматически Charset не устанавливают. Простой скрипт возвращающий русскую строку удет отображаться с кракозяблами. 

должно выглядеть как-то так

![monosomeoscriptweb](https://user-images.githubusercontent.com/55323/33407003-6c6ec174-d580-11e7-865c-ab446f5a3c0e.png)
